### PR TITLE
Adds fields caching in ResultSet

### DIFF
--- a/src/PharoADO/ADOFields.class.st
+++ b/src/PharoADO/ADOFields.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #ADOFields,
 	#superclass : #ADOObjects,
+	#instVars : [
+		'items'
+	],
 	#category : #'PharoADO-Core'
 }
 
@@ -12,12 +15,23 @@ ADOFields >> count [
 
 { #category : #accessing }
 ADOFields >> item: anInteger [
-	| field |
-	field := ADOField new.
-	field dispatchInstance: 
-		(dispatchInstance
-			propertyNamed: 'Item'
-			withArguments: { anInteger - 1 }).
-	^field
-		
+	^ (self items
+		at: anInteger
+		ifAbsent: [ nil ])
+			ifNil:  
+		 [ | field |
+			field := ADOField new.
+			field
+				dispatchInstance:
+					(dispatchInstance
+						propertyNamed: 'Item'
+						withArguments: {(anInteger - 1)}).
+			self items at: anInteger put: field ]
+]
+
+{ #category : #accessing }
+ADOFields >> items [
+
+	^items ifNil: [ items := Array new: self count ]
+
 ]

--- a/src/PharoADO/ADORecordset.class.st
+++ b/src/PharoADO/ADORecordset.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #ADORecordset,
 	#superclass : #ADOObjects,
+	#instVars : [
+		'fields'
+	],
 	#category : #'PharoADO-Core'
 }
 
@@ -38,8 +41,8 @@ ADORecordset >> cancelUpdate [
 
 { #category : #'initialize-release' }
 ADORecordset >> close [
-	dispatchInstance
-		dispatch: 'Close'
+	self resetFields.
+	dispatchInstance dispatch: 'Close'
 ]
 
 { #category : #'submorphs-add/remove' }
@@ -56,10 +59,10 @@ ADORecordset >> eof [
 
 { #category : #accessing }
 ADORecordset >> fields [ 
-	| fields |
-	fields := ADOFields new.
+
+	fields ifNil: [fields := ADOFields new.
 	fields dispatchInstance: 
-		(dispatchInstance propertyNamed: 'Fields').
+		(dispatchInstance propertyNamed: 'Fields')].
 	^fields
 ]
 
@@ -89,15 +92,15 @@ ADORecordset >> movePrevious [
 
 { #category : #'as yet unclassified' }
 ADORecordset >> open: aString activeConnection: aConnection cursorType: aCursorType lockType: aLockType options: anOptions [
-	dispatchInstance 
+	self resetFields.
+	dispatchInstance
 		dispatch: 'Open'
-		withArguments: { 
-			aString.
+		withArguments:
+			{aString.
 			aConnection dispatchInstance.
-			aCursorType .
+			aCursorType.
 			aLockType.
-			anOptions.
-		 }
+			anOptions}
 ]
 
 { #category : #'as yet unclassified' }
@@ -110,6 +113,11 @@ ADORecordset >> recordCount [
 ADORecordset >> requery [
 	dispatchInstance
 		dispatch: 'Requery'
+]
+
+{ #category : #'initialize-release' }
+ADORecordset >> resetFields [
+	fields := nil
 ]
 
 { #category : #'accessing structure variables' }


### PR DESCRIPTION
I did a small change in ADORecordset to have the fields as an instVar and also in ADOFields to have each ADOField in an `items` instVar. It is still slow compared to an ODBC API, but I got a 20x speedup. 
